### PR TITLE
Remove empty sync if a repository is not found in the database

### DIFF
--- a/src/Service/GithubApiService.php
+++ b/src/Service/GithubApiService.php
@@ -381,6 +381,7 @@ class GithubApiService
 
                 // Get the github repository from the given url if the object is null.
                 if ($repositorySync->getObject() === null) {
+                    $this->entityManager->remove($repositorySync);
                     $repository = $this->getGithubRepository($supports['software']);
                 }
 


### PR DESCRIPTION
A new sync is made a bit later in the process, and that is the one that gets the object.
